### PR TITLE
Fix highlighting for modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { parser } from "./tql.grammar";
 import { LRLanguage, LanguageSupport } from "@codemirror/language";
 import { styleTags, tags as t } from "@lezer/highlight";
 
-const punctuation = `"+" "-" "*" "/" "=" "." "'" ":" "!" "?" "<" ">" "@" "%" "&" "#" ";" "^" "\`"`;
+const punctuation = `"+" "-" "*" "/" "=" "." "'" ":" "::" "!" "?" "<" ">" "@" "%" "&" "#" ";" "^" "\`"`;
 
 export const TenzirQueryLang = LRLanguage.define({
   languageData: {
@@ -17,6 +17,7 @@ export const TenzirQueryLang = LRLanguage.define({
         "OpName! FnIdent": t.name,
         [punctuation]: t.punctuation,
         "LineComment BlockComment": t.comment,
+        ModuleIdent: t.variableName,
       }),
     ],
     // TODO: add folding later

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -11,7 +11,8 @@ import {
   Comma,
   Ident,
   FnIdent,
-  DollarIdent
+  DollarIdent,
+  ModuleIdent,
 } from "./parser.terms.js"
 
 type ContextData = {
@@ -95,6 +96,8 @@ export const identifiers = new ExternalTokenizer((input, stack) => {
   }
   if (input.peek(n) == code("(")) {
     token = FnIdent;
+  } else if (input.peek(n) == code(":") && input.peek(n + 1) == code(":")) {
+    token = ModuleIdent;
   }
   input.acceptToken(token, n);
 })

--- a/src/tql.grammar
+++ b/src/tql.grammar
@@ -11,7 +11,7 @@ _Stmt {
   AssignStmt |
   (kw<"let"> | kw<"if"> | kw<"match">) Soup }
 
-OpStmt { OpName ~op_name ~op_name2 Soup }
+OpStmt { (ModuleIdent | "::")* OpName ~op_name ~op_name2 Soup }
 
 AssignStmt[@dynamicPrecedence=1] {
   UnExpr ~op_name2 "=" Soup
@@ -27,6 +27,7 @@ Soup { _Any* }
 
 // Anything but { } | and newline.
 _Any {
+  ModuleIdent |
   FnIdent |
   Ident |
   DollarIdent |
@@ -112,7 +113,7 @@ Pipe { "|" }
   Scalar { $[0-9]($[0-9] | "." | "_")* $[a-zA-Z0-9_]* }
   @precedence { LineComment "/" }
   "+" "-" "*" "/" "," "=" "." "'" ":" "!" "?" "<" ">"
-  "@" "%" "&" "#" ";" "^" "`"
+  "@" "%" "&" "#" ";" "^" "`" "::"
   stringContent { ![\\\"]+ }
   rawStringContent { !["]+ }
   rawStringDelimEnd { "\"#" }
@@ -158,7 +159,8 @@ String {
 @external tokens identifiers from "./tokens.ts" {
   Ident,
   FnIdent,
-  DollarIdent
+  DollarIdent,
+  ModuleIdent
 }
 
 kw<term> { @specialize[@name={term}]<Ident, term> }

--- a/test/cases.txt
+++ b/test/cases.txt
@@ -109,7 +109,7 @@ every 1s {
 }
 deduplicate foo
 ==>
-Pipeline(OpStmt(OpName(Ident),Soup(Scalar,PipeExpr("{",OpStmt(OpName(Ident),Soup(Ident)),OpStmt(OpName(Ident),Soup(Ident)),"}"))),OpStmt(OpName(Ident),Soup(Ident)))
+Pipeline(OpStmt(OpName(Ident),Soup(Scalar,PipeExpr("{",OpStmt(ModuleIdent,OpName(Ident),Soup),OpStmt(OpName(Ident),Soup(Ident)),"}"))),OpStmt(OpName(Ident),Soup(Ident)))
 
 
 # Raw string literals
@@ -128,3 +128,9 @@ Pipeline(OpStmt(OpName(move),Soup(Ident,"=",Ident)))
 foo = move bar
 ==>
 Pipeline(AssignStmt(UnExpr(Ident),"=",Soup(move,Ident)))
+
+
+# Modules
+foo::bar baz::qux()
+==>
+Pipeline(OpStmt(ModuleIdent,OpName(Ident),Soup(ModuleIdent,FnIdent,"(",")")))


### PR DESCRIPTION
They were previously highlighted as operator names or normal identifiers. Now, they have their own category.