### PR TITLE
Pin patched transitive security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "rollup-plugin-ts": "^3.4.5",
     "typescript": "^4.9.5"
   },
+  "pnpm": {
+    "overrides": {
+      "picomatch": "4.0.4"
+    }
+  },
   "license": "MIT",
   "packageManager": "pnpm@9.8.0+sha512.8e4c3550fb500e808dbc30bb0ce4dd1eb614e30b1c55245f211591ec2cdf9c611cabd34e1364b42f564bd54b3945ed0f49d61d1bbf2ec9bd74b866fcdc723276"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  picomatch: 4.0.4
+
 importers:
 
   .:
@@ -231,8 +234,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   property-information@6.2.0:
@@ -399,7 +402,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 2.80.0
 
@@ -527,7 +530,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   property-information@6.2.0: {}
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -22,5 +22,10 @@
     "to-vfile": "^8.0.0",
     "unified": "^10.1.2",
     "vfile-reporter": "^8.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "diff": "5.2.2"
+    }
   }
 }

--- a/scripts/pnpm-lock.yaml
+++ b/scripts/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  diff: 5.2.2
+
 dependencies:
   rehype-document:
     specifier: ^6.1.0
@@ -127,8 +130,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /diff@5.1.0:
-    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+  /diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
     dev: false
 
@@ -757,7 +760,7 @@ packages:
     hasBin: true
     dependencies:
       dequal: 2.0.3
-      diff: 5.1.0
+      diff: 5.2.2
       kleur: 4.1.5
       sade: 1.8.1
     dev: false


### PR DESCRIPTION
## 🔍 Problem

- GitHub reported open vulnerabilities in transitive npm dependencies from both lockfiles.
- `picomatch@4.0.3` was pulled in from the main build toolchain.
- `diff@5.1.0` was pulled in from the docs/scripts toolchain.

## 🛠️ Solution

- Add pnpm overrides for `picomatch@4.0.4` and `diff@5.2.2`
- Refresh the affected lockfile entries so both patched versions are resolved
- Verify the main package with `pnpm audit`, `pnpm build`, and `pnpm test`

## 💬 Review

- Focus on whether pinning the transitive dependencies is acceptable as the minimal fix
- Replacing deprecated tooling is intentionally out of scope for this PR